### PR TITLE
Limit concurrent builder sessions

### DIFF
--- a/suave/builder/api/api_server.go
+++ b/suave/builder/api/api_server.go
@@ -8,7 +8,7 @@ import (
 
 // SessionManager is the backend that manages the session state of the builder API.
 type SessionManager interface {
-	NewSession() (string, error)
+	NewSession(context.Context) (string, error)
 	AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error)
 }
 
@@ -24,7 +24,7 @@ type Server struct {
 }
 
 func (s *Server) NewSession(ctx context.Context) (string, error) {
-	return s.sessionMngr.NewSession()
+	return s.sessionMngr.NewSession(ctx)
 }
 
 func (s *Server) AddTransaction(ctx context.Context, sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {

--- a/suave/builder/api/api_test.go
+++ b/suave/builder/api/api_test.go
@@ -30,10 +30,10 @@ func TestAPI(t *testing.T) {
 
 type nullSessionManager struct{}
 
-func (n *nullSessionManager) NewSession() (string, error) {
-	return "1", nil
+func (nullSessionManager) NewSession(ctx context.Context) (string, error) {
+	return "1", ctx.Err()
 }
 
-func (n *nullSessionManager) AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {
+func (nullSessionManager) AddTransaction(sessionId string, tx *types.Transaction) (*types.SimulateTransactionResult, error) {
 	return &types.SimulateTransactionResult{Logs: []*types.SimulatedLog{}}, nil
 }

--- a/suave/builder/session_manager_test.go
+++ b/suave/builder/session_manager_test.go
@@ -34,7 +34,7 @@ func TestSessionManager_SessionTimeout(t *testing.T) {
 func TestSessionManager_MaxConcurrentSessions(t *testing.T) {
 	t.Parallel()
 
-	const d = time.Millisecond * 10
+	const d = time.Millisecond * 100
 
 	mngr, _ := newSessionManager(t, &Config{
 		MaxConcurrentSessions: 1,


### PR DESCRIPTION
Hack: use a semaphore channel to limit the number of open sessions.

This is a hack because we're relying on session timeout behavior. Recommend ref-counting API that releases refs when block-height changes.