### PR TITLE
Update CI to use go1.22. Remove go1.20 (EOL).

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.20', '1.21.x' ]
+        go-version: ['1.21.x', '1.22.x']
         # goarch: [amd64, arm64]
 
     steps:


### PR DESCRIPTION
With the latest release of go 1.22, go 1.20 is at EOL.  This PR updates CI to test against supported Go versions.