### PR TITLE
FIX: fix docker compose so example tests successfully pass

### DIFF
--- a/suave/devenv/docker-compose.yml
+++ b/suave/devenv/docker-compose.yml
@@ -18,6 +18,9 @@ services:
       - --keystore=/keystore/keystore
       - --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
       - --password=/keystore/password.txt
+      - --suave.dev
+      - --suave.eth.remote_endpoint=http://suave-enabled-chain:8545
+      - --suave.eth.external-whitelist=172.17.0.1
     depends_on:
       - suave-enabled-chain
     volumes:
@@ -25,12 +28,28 @@ services:
     ports:
       - 8545:8545
       - 8546:8546
+    networks: 
+      - suave-net
   suave-enabled-chain:
     build: ../..
     command:
       - --dev
       - --dev.gaslimit=30000000
       - --http
+      - --http.addr=0.0.0.0
+      - --http.vhosts=*
+      - --http.corsdomain=*
+      - --datadir=/data
+      - --keystore=/keystore/keystore
+      - --password=/keystore/password.txt
+      - --unlock=0xB5fEAfbDD752ad52Afb7e1bD2E40432A485bBB7F
+      - --allow-insecure-unlock 
       - --ws
     ports:
       - 8555:8545
+    volumes:
+      - ./suave-ex-node:/keystore 
+    networks:
+      - suave-net
+networks:
+  suave-net:


### PR DESCRIPTION
Hi everyone!
I caught some issues with SUAPP example tests in my pr #19:
Next, I tried to run them from the main branch and got the same error as in ci log in my PR with env configurations 

```
_2024/03/02 15:58:21 Test address 1: 0x99A24Fe271a0f754fD55A48Cb3b2bC84f16875f7
panic: Post "http://localhost:8555": read tcp [::1]:36920->[::1]:8555: read: connection reset by peer

goroutine 1 [running]:
main.maybe(...)
	/home/runner/work/suave-execution-geth/suave-execution-geth/suapp-examples/examples/build-eth-block/main.go:87
main.main()
	/home/runner/work/suave-execution-geth/suave-execution-geth/suapp-examples/examples/build-eth-block/main.go:24 +0x[91](https://github.com/flashbots/suave-execution-geth/actions/runs/8101826092/job/22204681002?pr=19#step:8:92)1
exit status 2_
make: *** [Makefile:31: run-integration] Error 1
```

The issue was in docker-compose configuration, I fix it and locally all suapp examples pass 