### PR TITLE
Use Logs instead of entire SimulateTransactionResults

### DIFF
--- a/miner/builder.go
+++ b/miner/builder.go
@@ -131,28 +131,28 @@ func (b *Builder) addBundle(bundle *suavextypes.Bundle, env *environment) (*suav
 	revertingHashes := bundle.RevertingHashesMap()
 	egp := uint64(0)
 
-	var results []*suavextypes.SimulateTransactionResult
+	var logs []*suavextypes.SimulatedLog
 	for _, txn := range bundle.Txs {
 		result, err := b.addTransaction(txn, env)
-		results = append(results, result)
+		logs = append(logs, result.Logs...)
 		if err != nil {
 			if _, ok := revertingHashes[txn.Hash()]; ok {
 				// continue if the transaction is in the reverting hashes
 				continue
 			}
 			return &suavextypes.SimulateBundleResult{
-				Error:                      err.Error(),
-				SimulateTransactionResults: results,
-				Success:                    false,
+				Error:   err.Error(),
+				Logs:    logs,
+				Success: false,
 			}, err
 		}
 		egp += result.Egp
 	}
 
 	return &suavextypes.SimulateBundleResult{
-		Egp:                        egp,
-		SimulateTransactionResults: results,
-		Success:                    true,
+		Egp:     egp,
+		Logs:    logs,
+		Success: true,
 	}, nil
 }
 

--- a/miner/builder_test.go
+++ b/miner/builder_test.go
@@ -119,9 +119,7 @@ func TestBuilder_AddBundles_RevertHashes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	require.False(t, res[0].Success)
-	require.Len(t, res[0].SimulateTransactionResults, 2)
-	require.True(t, res[0].SimulateTransactionResults[0].Success)
-	require.False(t, res[0].SimulateTransactionResults[1].Success)
+	require.Len(t, res[0].Logs, 0)
 	require.Equal(t, big.NewInt(0), builder.env.state.GetBalance(testUserAddress))
 
 	bundle.RevertingHashes = []common.Hash{tx2.Hash()}
@@ -130,9 +128,7 @@ func TestBuilder_AddBundles_RevertHashes(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, res, 1)
 	require.True(t, res[0].Success)
-	require.Len(t, res[0].SimulateTransactionResults, 2)
-	require.True(t, res[0].SimulateTransactionResults[0].Success)
-	require.False(t, res[0].SimulateTransactionResults[1].Success)
+	require.Len(t, res[0].Logs, 0)
 	require.Equal(t, big.NewInt(1000), builder.env.state.GetBalance(testUserAddress))
 }
 
@@ -159,7 +155,7 @@ func TestBuilder_AddBundles_InvalidParams(t *testing.T) {
 	require.Len(t, res, 1)
 	require.False(t, res[0].Success)
 	require.Equal(t, ErrInvalidBlockNumber.Error(), res[0].Error)
-	require.Len(t, res[0].SimulateTransactionResults, 0)
+	require.Len(t, res[0].Logs, 0)
 	require.Equal(t, big.NewInt(0), builder.env.state.GetBalance(testUserAddress))
 
 	bundle = &suavextypes.Bundle{
@@ -173,7 +169,7 @@ func TestBuilder_AddBundles_InvalidParams(t *testing.T) {
 	require.Len(t, res, 1)
 	require.False(t, res[0].Success)
 	require.Equal(t, ErrExceedsMaxBlock.Error(), res[0].Error)
-	require.Len(t, res[0].SimulateTransactionResults, 0)
+	require.Len(t, res[0].Logs, 0)
 	require.Equal(t, big.NewInt(0), builder.env.state.GetBalance(testUserAddress))
 
 	bundle = &suavextypes.Bundle{
@@ -184,7 +180,7 @@ func TestBuilder_AddBundles_InvalidParams(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, res[0].Success)
 	require.Equal(t, ErrEmptyTxs.Error(), res[0].Error)
-	require.Len(t, res[0].SimulateTransactionResults, 0)
+	require.Len(t, res[0].Logs, 0)
 	require.Equal(t, big.NewInt(0), builder.env.state.GetBalance(testUserAddress))
 }
 

--- a/suave/builder/api/api.go
+++ b/suave/builder/api/api.go
@@ -61,10 +61,10 @@ type SimulateTransactionResult struct {
 }
 
 type SimulateBundleResult struct {
-	Egp                        uint64                       `json:"egp"`
-	SimulateTransactionResults []*SimulateTransactionResult `json:"simulateTransactionResults"`
-	Success                    bool                         `json:"success"`
-	Error                      string                       `json:"error"`
+	Egp     uint64          `json:"egp"`
+	Logs    []*SimulatedLog `json:"logs"`
+	Success bool            `json:"success"`
+	Error   string          `json:"error"`
 }
 
 // field type overrides for gencodec


### PR DESCRIPTION
Suave.sol does not compile with "stack too deep" due to nested structs for `SimulateBundleResult`. This PR does a diet to reduce number of local variables 