### PR TITLE
fix: getSession call needs one more param in GetBalance

### DIFF
--- a/suave/builder/session_manager.go
+++ b/suave/builder/session_manager.go
@@ -197,7 +197,7 @@ func (s *SessionManager) Bid(sessionId string, blsPubKey phase0.BLSPubKey) (*api
 }
 
 func (s *SessionManager) GetBalance(sessionId string, addr common.Address) (*big.Int, error) {
-	builder, err := s.getSession(sessionId)
+	builder, err := s.getSession(sessionId, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GetBalance is broken at this moment because getSession needs two params